### PR TITLE
optional vendor prefixes through global setting or mixin param

### DIFF
--- a/_burger.scss
+++ b/_burger.scss
@@ -5,8 +5,13 @@
 // (---) bottom -> &:after
 
 
-// Burger
-@mixin burger($width: 30px, $height: 5px, $gutter: 3px, $color: #000, $border-radius: 0, $transition-duration: .3s) {
+/**
+ * Burger
+ */
+
+$sass-burger-add-transition-vendor-prefixes: true !default;
+
+@mixin burger($width: 30px, $height: 5px, $gutter: 3px, $color: #000, $border-radius: 0, $transition-duration: .3s, $add-vendor-prefixes: $sass-burger-add-transition-vendor-prefixes) {
     $burger-height: $height !global;
     $burger-gutter: $gutter !global;
 
@@ -28,14 +33,18 @@
             border-radius: $border-radius;
         }
 
-        -webkit-transition-property: background-color, -webkit-transform;
-        -moz-transition-property: background-color, -moz-transform;
-        -o-transition-property: background-color, -o-transform;
+        @if $add-vendor-prefixes {
+            -webkit-transition-property: background-color, -webkit-transform;
+            -moz-transition-property: background-color, -moz-transform;
+            -o-transition-property: background-color, -o-transform;
+        }
         transition-property: background-color, transform;
 
-        -webkit-transition-duration: $transition-duration;
-        -moz-transition-duration: $transition-duration;
-        -o-transition-duration: $transition-duration;
+        @if $add-vendor-prefixes {
+            -webkit-transition-duration: $transition-duration;
+            -moz-transition-duration: $transition-duration;
+            -o-transition-duration: $transition-duration;
+        }
         transition-duration: $transition-duration;
     }
 
@@ -86,17 +95,21 @@
         background-color: transparent;
     }
     &:before {
-        -webkit-transform: translateY($burger-gutter + $burger-height) rotate(45deg);
-        -moz-transform: translateY($burger-gutter + $burger-height) rotate(45deg);
-        -ms-transform: translateY($burger-gutter + $burger-height) rotate(45deg);
-        -o-transform: translateY($burger-gutter + $burger-height) rotate(45deg);
+        @if $add-vendor-prefixes {
+            -webkit-transform: translateY($burger-gutter + $burger-height) rotate(45deg);
+            -moz-transform: translateY($burger-gutter + $burger-height) rotate(45deg);
+            -ms-transform: translateY($burger-gutter + $burger-height) rotate(45deg);
+            -o-transform: translateY($burger-gutter + $burger-height) rotate(45deg);
+        }
         transform: translateY($burger-gutter + $burger-height) rotate(45deg);
     }
     &:after {
-        -webkit-transform: translateY(-($burger-gutter + $burger-height)) rotate(-45deg);
-        -moz-transform: translateY(-($burger-gutter + $burger-height)) rotate(-45deg);
-        -ms-transform: translateY(-($burger-gutter + $burger-height)) rotate(-45deg);
-        -o-transform: translateY(-($burger-gutter + $burger-height)) rotate(-45deg);
+        @if $add-vendor-prefixes {
+            -webkit-transform: translateY(-($burger-gutter + $burger-height)) rotate(-45deg);
+            -moz-transform: translateY(-($burger-gutter + $burger-height)) rotate(-45deg);
+            -ms-transform: translateY(-($burger-gutter + $burger-height)) rotate(-45deg);
+            -o-transform: translateY(-($burger-gutter + $burger-height)) rotate(-45deg);
+        }
         transform: translateY(-($burger-gutter + $burger-height)) rotate(-45deg);
     }
 }

--- a/_burger.scss
+++ b/_burger.scss
@@ -9,9 +9,9 @@
  * Burger
  */
 
-$sass-burger-add-transition-vendor-prefixes: true !default;
+$sass-burger-add-vendor-prefixes: true !default;
 
-@mixin burger($width: 30px, $height: 5px, $gutter: 3px, $color: #000, $border-radius: 0, $transition-duration: .3s, $add-vendor-prefixes: $sass-burger-add-transition-vendor-prefixes) {
+@mixin burger($width: 30px, $height: 5px, $gutter: 3px, $color: #000, $border-radius: 0, $transition-duration: .3s, $add-vendor-prefixes: $sass-burger-add-vendor-prefixes) {
     $burger-height: $height !global;
     $burger-gutter: $gutter !global;
 
@@ -19,9 +19,11 @@ $sass-burger-add-transition-vendor-prefixes: true !default;
     margin-top: $height + $gutter;
     margin-bottom: $height + $gutter;
 
-    -webkit-user-select: none;
-    -moz-user-select: none;
-    -ms-user-select: none;
+    @if $add-vendor-prefixes {
+        -webkit-user-select: none;
+        -moz-user-select: none;
+        -ms-user-select: none;
+    }
     user-select: none;
 
     &, &:before, &:after {
@@ -90,7 +92,7 @@ $sass-burger-add-transition-vendor-prefixes: true !default;
 
 
 // Burger animations
-@mixin burger-to-cross {
+@mixin burger-to-cross($add-vendor-prefixes: $sass-burger-add-vendor-prefixes) {
     & {
         background-color: transparent;
     }


### PR DESCRIPTION
This adds a global var `$sass-burger-add-transition-vendor-prefixes` that defaults to `true` and is the default value for the new `$add-vendor-prefixes` mixin parameter.

If `$add-vendor-prefixes` is `true`, vendor prefixes are added to the output, otherwise not.

This makes sense since a lot of people do vendor prefixing with a tool like Autoprefixer instead of sass mixins.