### PR TITLE
Failover for old version sass compiler

### DIFF
--- a/_burger.scss
+++ b/_burger.scss
@@ -11,9 +11,12 @@
  * Burger
  */
 
+$burger-height: 5px !default ;
+$burger-gutter: 3px !default;
+
 @mixin burger($width: 30px, $height: 5px, $gutter: 3px, $color: #000, $border-radius: 0, $transition-duration: .3s) {
-    $burger-height: $height !global;
-    $burger-gutter: $gutter !global;
+    $burger-height: $height;
+    $burger-gutter: $gutter;
 
     position: relative;
     margin-top: $height + $gutter;


### PR DESCRIPTION
When I use latest gulp-sass to do compile, I will get error "gulp sass unbound variable $burger-gutter" which is caused by gulp sass doesn't support "!global". Add this kind of failover for old version sass compiler.