### PR TITLE
Add support for Ruby Sass and Compass

### DIFF
--- a/lib/sass-burger.rb
+++ b/lib/sass-burger.rb
@@ -1,0 +1,15 @@
+project_path = File.join(File.dirname(__FILE__), '..')
+
+if (defined? Compass)
+  Compass::Frameworks.register(
+    'sass-burger',
+    :path => project_path,
+    :stylesheets_directory => project_path
+  )
+else
+  if ENV.has_key?('SASS_PATH')
+    ENV['SASS_PATH'] = ENV['SASS_PATH'] + File::PATH_SEPARATOR + project_path
+  else
+    ENV['SASS_PATH'] = project_path
+  end
+end

--- a/sass-burger.gemspec
+++ b/sass-burger.gemspec
@@ -1,0 +1,19 @@
+# -*- encoding: utf-8 -*-
+
+Gem::Specification.new do |spec|
+  spec.name        = 'sass-burger'
+  spec.version     = '1.3.0'
+  spec.homepage    = 'http://joren.co/sass-burger/'
+  spec.authors     = ['Joren Van Hee']
+  spec.description = %q{A Sass mixin for creating hamburger icons.}
+  spec.summary     = %q{Sass hamburger icon mixin.}
+  spec.licenses    = ['MIT']
+
+  spec.add_runtime_dependency('sass', '~> 3.3')
+
+  spec.files       = %w(
+    lib/sass-burger.rb
+    sass-burger.gemspec
+    _burger.scss
+  )
+end


### PR DESCRIPTION
I have created a `gemspec` and a script to add the main main directory to Compass or Sass.

Please, as soon as you merge this, build the gem usiing `gem build sass-burger.gemspec` and then publish using `gem push sass-burger-1.3.0.gem`

For the publishing, you need an account on rubygems.org. If you are not familiar with publishing gems, read [this](http://guides.rubygems.org/publishing/)
